### PR TITLE
feat: add accessibility link

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -80,6 +80,7 @@ class SiteFooter extends React.Component {
                 {this.renderLinkIfExists(process.env.PRIVACY_POLICY_URL, 'Privacy Policy')}
                 {this.renderLinkIfExists(process.env.HONOR_CODE_URL, 'Honor Code')}
                 {this.renderLinkIfExists(process.env.Contact, 'Contact')}
+                {this.renderLinkIfExists(process.env.ACCESSIBILITY_URL, 'Accessibility')}
                 {this.renderLinkIfExists(process.env.SUPPORT_CENTER_URL, process.env.SUPPORT_CENTER_TEXT || 'FAQ & Help')}
               </ul>
             </div>

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -65,6 +65,13 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
           </li>
           <li>
             <a
+              href="https://accessibility.mit.edu/"
+            >
+              Accessibility
+            </a>
+          </li>
+          <li>
+            <a
               href="http://localhost:18000/about"
             >
               SUPPORT CENTER
@@ -183,6 +190,13 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
           </li>
           <li>
             <a
+              href="https://accessibility.mit.edu/"
+            >
+              Accessibility
+            </a>
+          </li>
+          <li>
+            <a
               href="http://localhost:18000/about"
             >
               SUPPORT CENTER
@@ -259,6 +273,13 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
               href="http://localhost:18000/tos_and_honor"
             >
               Honor Code
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://accessibility.mit.edu/"
+            >
+              Accessibility
             </a>
           </li>
           <li>

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -36,3 +36,4 @@ process.env.SITE_URL = 'http://localhost:18000/';
 process.env.LOGO_ALT_TEXT = 'alt text';
 process.env.SHOW_LOGO = true;
 process.env.SUPPORT_EMAIL = 'webmaster@email.com';
+process.env.ACCESSIBILITY_URL = 'https://accessibility.mit.edu/'

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -36,4 +36,4 @@ process.env.SITE_URL = 'http://localhost:18000/';
 process.env.LOGO_ALT_TEXT = 'alt text';
 process.env.SHOW_LOGO = true;
 process.env.SUPPORT_EMAIL = 'webmaster@email.com';
-process.env.ACCESSIBILITY_URL = 'https://accessibility.mit.edu/'
+process.env.ACCESSIBILITY_URL = 'https://accessibility.mit.edu/';


### PR DESCRIPTION
Ticket: https://github.com/mitodl/hq/issues/631 & https://github.com/mitodl/hq/issues/759

Related PR https://github.com/mitodl/ol-infrastructure/pull/1370

Testing Guidelines:
- Follow the [readme](https://github.com/mitodl/frontend-component-footer-mitol) to install the footer in the Learning MFE.
- Add `ACCESSIBILITY_URL=https://accessibility.mit.edu/` in the `.env.development` of the Learning MFE.
- `Accessibility` link should be visible in the Footer.

Screenshot:
<img width="1750" alt="Screen Shot 2023-02-22 at 7 45 27 PM" src="https://user-images.githubusercontent.com/52656433/220657352-a053bebe-e2bb-4b4d-a8b4-b374759f43f0.png">
